### PR TITLE
Add Safe Haskell annotation

### DIFF
--- a/Data/SortedList.hs
+++ b/Data/SortedList.hs
@@ -1,5 +1,5 @@
 
-{-# LANGUAGE CPP, TypeFamilies #-}
+{-# LANGUAGE CPP, Safe, TypeFamilies #-}
 
 -- | This module defines a type for sorted lists, together
 --   with several functions to create and use values of that


### PR DESCRIPTION
This allows modules that annotate themselves as `Safe` (e.g. for protection against `unsafePerformIO` usages) to retain this annotation when utilizing `Data.SortedList`.